### PR TITLE
fix: use circulation instead of recursion

### DIFF
--- a/lib/node-nailgun-client.js
+++ b/lib/node-nailgun-client.js
@@ -87,20 +87,24 @@ module.exports.exec = function(cmd, args, options) {
     sendText(CHUNK_TYPES.STDIN_EOF, '');
   });
 
-  function getChunksFromBuffer(bufferData) {
-    if (buf.length < CHUNK_HEADER_LEN) { return []; }
+  function getChunksFromBuffer() {
+    var chunks = [];
 
-    var size = buf.readUInt32BE(0);
-    var end = CHUNK_HEADER_LEN + size;
+    while (true) {
+      if (buf.length < CHUNK_HEADER_LEN) { return chunks; }
 
-    if (end > buf.length) { return []; }
+      var size = buf.readUInt32BE(0);
+      var end = CHUNK_HEADER_LEN + size;
 
-    var chunk = {};
-    chunk.type = String.fromCharCode(buf.readUInt8(4));
-    chunk.data = buf.slice(CHUNK_HEADER_LEN, end);
+      if (end > buf.length) { return chunks; }
 
-    buf = buf.slice(end);
-    return [chunk].concat(getChunksFromBuffer());
+      var chunk = {};
+      chunk.type = String.fromCharCode(buf.readUInt8(4));
+      chunk.data = buf.slice(CHUNK_HEADER_LEN, end);
+
+      buf = buf.slice(end);
+      chunks.push(chunk);
+    }
   };
 
   function exit(code) {


### PR DESCRIPTION
I've received some RangeError, and I can't find any logic problem with this function, maybe we should use circulation instead of recursion here to avoid this error.

```js
RangeError: Maximum call stack size exceeded
    at getChunksFromBuffer (/home/admin/release/V20190120001037/node_modules/_node-nailgun-client@0.1.0@node-nailgun-client/lib/node-nailgun-client.js:103:27)
    at getChunksFromBuffer (/home/admin/release/V20190120001037/node_modules/_node-nailgun-client@0.1.0@node-nailgun-client/lib/node-nailgun-client.js:103:27)
    at getChunksFromBuffer (/home/admin/release/V20190120001037/node_modules/_node-nailgun-client@0.1.0@node-nailgun-client/lib/node-nailgun-client.js:103:27)
```